### PR TITLE
Add CentOS 7 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 out/
+.DS_Store

--- a/build
+++ b/build
@@ -7,7 +7,7 @@ src_dir=$PWD/src
 out_dir=$PWD/out
 archive_dir=$out_dir/archive
 build_dir=$out_dir/build
-zfs_builder=delphix/zfs-builder:latest
+zfs_builder=titandata/zfs-builder:latest
 
 function usage() {
   echo "Usage: $0 [-u] [kernel_release ...]" 1>&2

--- a/src/3.10.0-957.1.3.el7.x86_64/centos-release
+++ b/src/3.10.0-957.1.3.el7.x86_64/centos-release
@@ -1,0 +1,1 @@
+CentOS Linux release 7.6.1810 (Core)

--- a/src/3.10.0-957.1.3.el7.x86_64/uname
+++ b/src/3.10.0-957.1.3.el7.x86_64/uname
@@ -1,0 +1,1 @@
+Linux ip.compute.internal 3.10.0-957.1.3.el7.x86_64 #1 SMP Thu Nov 29 14:49:43 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux


### PR DESCRIPTION
## Issues Addressed

Fixes #2

## Proposed Changes

This adds the files required to build ZFS for the latest CentOS 7 release. While I was here, I also updated the build to use the new titan community docker image, and also tweaked .gitignore since I had some lingering MacOS files.

## Testing

```
./build 3.10.0-957.1.3.el7.x86_64
...
Creating userland archive zfs-0.8.1-userland.tar.gz
Creating kernel archive zfs-0.8.1-3.10.0-957.1.3.el7.x86_64.tar.gz
```