### PR TITLE
Automated Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,15 @@ branches:
 env:
   # Userland build
   - MODE=-u KERNEL=4.9.184-linuxkit
+  # LinuxKit variants
+  - MODE=-k KERNEL=4.9.184-linuxkit
+  - MODE=-k KERNEL=4.9.125-linuxkit
+  # Ubuntu variants
+  - MODE=-k KERNEL=5.0.0-25-generic
+  - MODE=-k KERNEL=4.15.0-1034-gcp
+  - MODE=-k KERNEL=4.15.0-1044-aws
+  # CentOS variants
+  - MODE=-k KERNEL=3.10.0-957.1.3.el7.x86_64
 
 script:
   - bash ./build -b $S3_URL $MODE $KERNEL

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,24 @@
 language: shell
 os: linux
 services: docker
-cache:
-  directories:
-    - out/archive
+
 branches:
   only:
     - feature/travis
     - /^untagged/
+
+cache:
+  directories:
+    - out/archive
+
 env:
   - TARGET=5.0.0-25-generic
   - TARGET=4.9.125-linuxkit
+script:
+  - bash ./build $TARGET
+
 matrix:
   include:
-    - stage: build
-      script:
-        - bash ./build $TARGET
     - stage: deploy
       deploy:
         provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,31 +14,45 @@ cache:
   directories:
     - out/archive
 
-env:
-  # Ubuntu variants
-  - TARGET=5.0.0-25-generic
-  - TARGET=4.15.0-1034-gcp
-  - TARGET=4.15.0-1044-aws
-  # LinuxKit variants
-  - TARGET=4.9.125-linuxkit
-  - TARGET=4.9.184-linuxkit
-  # CentOS variants
-  - TARGET=3.10.0-957.1.3.el7.x86_64
-script:
-  - ls out/archive
-  - bash ./build $TARGET
+build_kernel: &build_kernel
+  script:
+    - bash ./build -k $KERNEL
 
-before_deploy:
-  - git config --local user.name "Eric Schrock"
-  - git config --local user.email "Eric.Schrock@delphix.com"
-  - export TRAVIS_TAG=${TRAVIS_TAG:-release-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
-  - git tag $TRAVIS_TAG
+matrix:
+  include:
+    # Userland
+    - stage: build
+      script:
+        - bash ./build -u
+    # LinuxKit variants
+    - <<: *build_kernel
+      env: KERNEL: 4.9.184-linuxkit
+    - <<: *build_kernel
+      env: KERNEL: 4.9.125-linuxkit
+    # Ubuntu variants
+    - <<: *build_kernel
+      env: KERNEL: 5.0.0-25-generic
+    - <<: *build_kernel
+      env: KERNEL: 4.15.0-1034-gcp
+    - <<: *build_kernel
+      env: KERNEL: 4.15.0-1044-aws
+    # CentOS variants
+    - <<: *build_kernel
+      env: KERNEL: 3.10.0-957.1.3.el7.x86_64
 
-deploy:
-  provider: releases
-  api_key:
-    secure: $GITHUB_TOKEN
-  file_glob: true
-  file: out/archive/*
-  on:
-    branch: feature/travis
+    # Deploy stage
+    - stage: deploy
+      before_deploy:
+        - ls out/archive
+        - git config --local user.name "Eric Schrock"
+        - git config --local user.email "Eric.Schrock@delphix.com"
+        - export TRAVIS_TAG=${TRAVIS_TAG:-release-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
+        - git tag $TRAVIS_TAG
+      deploy:
+        provider: releases
+        api_key:
+          secure: $GITHUB_TOKEN
+        file_glob: true
+        file: out/archive/*
+        on:
+          branch: feature/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ deploy:
   file_glob: true
   draft: true
   on:
+    branch: feature/travis
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
     # LinuxKit variants
     - &build-kernel
       script:
+        - ls out/archive
         - bash ./build -k $KERNEL
       env: KERNEL=4.9.184-linuxkit
     - <<: *build-kernel

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,14 @@ env:
 script:
   - bash ./build $TARGET
 
-deploy:
-  provider: releases
-  api_key:
-    secure: $GITHUB_TOKEN
-  file_glob: true
-  file: out/archive/*
-  skip_cleanup: true
-  on:
-    branch: feature/travis
+matrix:
+  include:
+    - stage: deploy
+      deploy:
+        provider: releases
+        api_key:
+          secure: $GITHUB_TOKEN
+        file_glob: true
+        file: out/archive/*
+        on:
+          branch: feature/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,5 @@
 language: generic
+services:
+  - docker
+script:
+  - bash ./build 5.0.0-25-generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ env:
   - TARGET=5.0.0-25-generic
   - TARGET=4.9.125-linuxkit
 script:
-  - bash ./build $TARGET
+  - ls out/archive
+#  - bash ./build $TARGET
 
 matrix:
   include:
@@ -24,7 +25,7 @@ matrix:
         provider: releases
         api_key:
           secure: $GITHUB_TOKEN
-        file: out/archive/*
         file_glob: true
+        file: out/archive/*
         on:
           branch: feature/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
     - /^untagged/
 jobs:
   include:
-    - stage: test
+    - stage: build
       script:
         - bash ./build 5.0.0-25-generic
     - stage: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
     # Userland
     - stage: build
       script:
+        - ls out/archive
         - bash ./build -u
 
     # LinuxKit variants

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,3 @@ deploy:
   upload-dir: $S3_FOLDER
   skip_cleanup: true
   local_dir: out/archive
-  on:
-    branch: feature/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ services: docker
 branches:
   only:
     - feature/travis
-    - /^untagged/
+
+branches:
+  except:
+    - /^release-/
 
 cache:
   directories:
@@ -28,7 +31,7 @@ script:
 before_deploy:
   - git config --local user.name "Eric Schrock"
   - git config --local user.email "Eric.Schrock@delphix.com"
-  - export TRAVIS_TAG=${TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
+  - export TRAVIS_TAG=${TRAVIS_TAG:-release-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
   - git tag $TRAVIS_TAG
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ deploy:
   access_key_id: $AWS_ACCESS_KEY
   secret_access_key: $AWS_SECRET_KEY
   bucket: $S3_BUCKET
-  upload_dir: $S3_FOLDER
+  upload-dir: $S3_FOLDER
   local_dir: out/archive
   on:
     branch: feature/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,19 @@
 language: shell
 os: linux
 services: docker
+cache:
+  directories:
+    - out/archive
 branches:
   only:
     - feature/travis
     - /^untagged/
+env:
+  - TARGET=5.0.0-25-generic
+  - TARGET=4.9.125-linuxkit
 matrix:
   include:
     - stage: build
-      env:
-        - TARGET=5.0.0-25-generic
-        - TARGET=4.9.125-linuxkit
       script:
         - bash ./build $TARGET
     - stage: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,52 +10,18 @@ branches:
   except:
     - /^release-/
 
-cache:
-  directories:
-    - out/archive
+env:
+  - MODE=-u KERNEL=4.9.184-linuxkit
 
-matrix:
-  include:
-    # Userland
-    - stage: build
-      script:
-        - ls out/archive
-        - bash ./build -u
+script:
+  - bash ./build -b $S3_URL $MODE $KERNEL
 
-    # LinuxKit variants
-    - &build-kernel
-      script:
-        - ls out/archive
-        - bash ./build -k $KERNEL
-      env: KERNEL=4.9.184-linuxkit
-    - <<: *build-kernel
-      env: KERNEL=4.9.125-linuxkit
-
-    # Ubuntu variants
-    - <<: *build-kernel
-      env: KERNEL=5.0.0-25-generic
-    - <<: *build-kernel
-      env: KERNEL=4.15.0-1034-gcp
-    - <<: *build-kernel
-      env: KERNEL=4.15.0-1044-aws
-
-    # CentOS variants
-    - <<: *build-kernel
-      env: KERNEL=3.10.0-957.1.3.el7.x86_64
-
-    # Deploy stage
-    - stage: deploy
-      before_deploy:
-        - ls out/archive
-        - git config --local user.name "Eric Schrock"
-        - git config --local user.email "Eric.Schrock@delphix.com"
-        - export TRAVIS_TAG=${TRAVIS_TAG:-release-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
-        - git tag $TRAVIS_TAG
-      deploy:
-        provider: releases
-        api_key:
-          secure: $GITHUB_TOKEN
-        file_glob: true
-        file: out/archive/*
-        on:
-          branch: feature/travis
+deploy:
+  provider: s3
+  access_key_id: $AWS_ACCESS_KEY
+  secret_access_key: $AWS_SECRET_KEY
+  bucket: $S3_BUCKET
+  upload_dir: $S3_FOLDER
+  local_dir: out/archive
+  on:
+    branch: feature/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,8 @@ branches:
   only:
     - feature/travis
 
-branches:
-  except:
-    - /^release-/
-
 env:
+  # Userland build
   - MODE=-u KERNEL=4.9.184-linuxkit
 
 script:
@@ -22,6 +19,7 @@ deploy:
   secret_access_key: $AWS_SECRET_KEY
   bucket: $S3_BUCKET
   upload-dir: $S3_FOLDER
+  skip_cleanup: true
   local_dir: out/archive
   on:
     branch: feature/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,19 +12,30 @@ cache:
     - out/archive
 
 env:
+  # Ubuntu variants
   - TARGET=5.0.0-25-generic
+  - TARGET=4.15.0-1034-gcp
+  - TARGET=4.15.0-1044-aws
+  # LinuxKit variants
   - TARGET=4.9.125-linuxkit
+  - TARGET=4.9.184-linuxkit
+  # CentOS variants
+  - TARGET=3.10.0-957.1.3.el7.x86_64
 script:
+  - ls out/archive
   - bash ./build $TARGET
 
-matrix:
-  include:
-    - stage: deploy
-      deploy:
-        provider: releases
-        api_key:
-          secure: $GITHUB_TOKEN
-        file_glob: true
-        file: out/archive/*
-        on:
-          branch: feature/travis
+before_deploy:
+  - git config --local user.name "Eric Schrock"
+  - git config --local user.email "Eric.Schrock@delphix.com"
+  - export TRAVIS_TAG=${TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
+  - git tag $TRAVIS_TAG
+
+deploy:
+  provider: releases
+  api_key:
+    secure: $GITHUB_TOKEN
+  file_glob: true
+  file: out/archive/*
+  on:
+    branch: feature/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,12 @@ services:
   - docker
 script:
   - bash ./build 5.0.0-25-generic
+deploy:
+  provider: releases
+  api_key:
+    secure: qWE/KeSH0bYu20gIaXKx0jh2v9MNzzUYBCNiy23kisIyFCdVDqgBFQSGIPHU8mQaO3pcYI3XoctJbirnDEMd5RDvNMZZfHOfEkebxWpY6Eo95SS78Xds4AU0IOA1ZFxzdgGL+1pvXtnjzuTXQD9w/APjKpJhiFsiiTbp1wfeahjBEWZIrR+UBrvQLiIlAOtG8O2Lh07CUSThtSRGNaoQ7q62jOV+bNNqK0ttaSO4AOZfGPzRZ7kM6dNwVlVnUzzHiJOQfZscu/W2QZEmFkOM0dQ6O2ZUxooZcthA59pZZIiwtS+tMfWEj6Tm77XuYfVDfGCXyoFu57lupUXC+fWUI1lbiNsVs88fQrTx28fix8nQOCT/oPd9l60ksagaCwa0YwCaYcs2aRFGVHOdcihFTLp36NY4/QjfsXSeMF3ZeCBwMnvJscngtKR3hzzR3mm69sfaWNPYZyzEG4TJadX1y9OiY8jrk3uQFjfH6JO4/Np2/zk55r0trCq6eiGUhv/HCFnDxmJJGdQReHesulvdi9rcLnWxxfI7LdwqIxONw/B4K4tr9NODS/IQvNxw17+z6MW6agAA4aM6aObm/C1Hxy0svLYzRRxCs9+sZqHlPimRx9xKq8j5Ruk11cGrsGYLjYL/aM9wy7ZOHe0O8cRw3uQbp1tJauJfCyD4f3srDzs=
+  file: out/archive/*
+  file_glob: true
+  draft: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,14 @@ env:
   - TARGET=5.0.0-25-generic
   - TARGET=4.9.125-linuxkit
 script:
-  - ls out/archive
-#  - bash ./build $TARGET
+  - bash ./build $TARGET
 
-matrix:
-  include:
-    - stage: deploy
-      deploy:
-        provider: releases
-        api_key:
-          secure: $GITHUB_TOKEN
-        file_glob: true
-        file: out/archive/*
-        on:
-          branch: feature/travis
+deploy:
+  provider: releases
+  api_key:
+    secure: $GITHUB_TOKEN
+  file_glob: true
+  file: out/archive/*
+  skip_cleanup: true
+  on:
+    branch: feature/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,31 +14,32 @@ cache:
   directories:
     - out/archive
 
-build_kernel: &build_kernel
-  script:
-    - bash ./build -k $KERNEL
-
 matrix:
   include:
     # Userland
     - stage: build
       script:
         - bash ./build -u
+
     # LinuxKit variants
-    - <<: *build_kernel
-      env: KERNEL: 4.9.184-linuxkit
-    - <<: *build_kernel
-      env: KERNEL: 4.9.125-linuxkit
+    - &build-kernel
+      script:
+        - bash ./build -k $KERNEL
+      env: KERNEL=4.9.184-linuxkit
+    - <<: *build-kernel
+      env: KERNEL=4.9.125-linuxkit
+
     # Ubuntu variants
-    - <<: *build_kernel
-      env: KERNEL: 5.0.0-25-generic
-    - <<: *build_kernel
-      env: KERNEL: 4.15.0-1034-gcp
-    - <<: *build_kernel
-      env: KERNEL: 4.15.0-1044-aws
+    - <<: *build-kernel
+      env: KERNEL=5.0.0-25-generic
+    - <<: *build-kernel
+      env: KERNEL=4.15.0-1034-gcp
+    - <<: *build-kernel
+      env: KERNEL=4.15.0-1044-aws
+
     # CentOS variants
-    - <<: *build_kernel
-      env: KERNEL: 3.10.0-957.1.3.el7.x86_64
+    - <<: *build-kernel
+      env: KERNEL=3.10.0-957.1.3.el7.x86_64
 
     # Deploy stage
     - stage: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
 language: generic
 services:
   - docker
-script:
-  - bash ./build 5.0.0-25-generic
-deploy:
-  provider: releases
-  api_key:
-    secure: qWE/KeSH0bYu20gIaXKx0jh2v9MNzzUYBCNiy23kisIyFCdVDqgBFQSGIPHU8mQaO3pcYI3XoctJbirnDEMd5RDvNMZZfHOfEkebxWpY6Eo95SS78Xds4AU0IOA1ZFxzdgGL+1pvXtnjzuTXQD9w/APjKpJhiFsiiTbp1wfeahjBEWZIrR+UBrvQLiIlAOtG8O2Lh07CUSThtSRGNaoQ7q62jOV+bNNqK0ttaSO4AOZfGPzRZ7kM6dNwVlVnUzzHiJOQfZscu/W2QZEmFkOM0dQ6O2ZUxooZcthA59pZZIiwtS+tMfWEj6Tm77XuYfVDfGCXyoFu57lupUXC+fWUI1lbiNsVs88fQrTx28fix8nQOCT/oPd9l60ksagaCwa0YwCaYcs2aRFGVHOdcihFTLp36NY4/QjfsXSeMF3ZeCBwMnvJscngtKR3hzzR3mm69sfaWNPYZyzEG4TJadX1y9OiY8jrk3uQFjfH6JO4/Np2/zk55r0trCq6eiGUhv/HCFnDxmJJGdQReHesulvdi9rcLnWxxfI7LdwqIxONw/B4K4tr9NODS/IQvNxw17+z6MW6agAA4aM6aObm/C1Hxy0svLYzRRxCs9+sZqHlPimRx9xKq8j5Ruk11cGrsGYLjYL/aM9wy7ZOHe0O8cRw3uQbp1tJauJfCyD4f3srDzs=
-  file: out/archive/*
-  file_glob: true
-  draft: true
-  on:
-    branch: feature/travis
-    tags: true
+branches:
+  only:
+    - feature/travis
+    - /^untagged/
+jobs:
+  include:
+    - stage: test
+      script:
+        - bash ./build 5.0.0-25-generic
+    - stage: deploy
+        deploy:
+          provider: releases
+          api_key:
+            secure: qWE/KeSH0bYu20gIaXKx0jh2v9MNzzUYBCNiy23kisIyFCdVDqgBFQSGIPHU8mQaO3pcYI3XoctJbirnDEMd5RDvNMZZfHOfEkebxWpY6Eo95SS78Xds4AU0IOA1ZFxzdgGL+1pvXtnjzuTXQD9w/APjKpJhiFsiiTbp1wfeahjBEWZIrR+UBrvQLiIlAOtG8O2Lh07CUSThtSRGNaoQ7q62jOV+bNNqK0ttaSO4AOZfGPzRZ7kM6dNwVlVnUzzHiJOQfZscu/W2QZEmFkOM0dQ6O2ZUxooZcthA59pZZIiwtS+tMfWEj6Tm77XuYfVDfGCXyoFu57lupUXC+fWUI1lbiNsVs88fQrTx28fix8nQOCT/oPd9l60ksagaCwa0YwCaYcs2aRFGVHOdcihFTLp36NY4/QjfsXSeMF3ZeCBwMnvJscngtKR3hzzR3mm69sfaWNPYZyzEG4TJadX1y9OiY8jrk3uQFjfH6JO4/Np2/zk55r0trCq6eiGUhv/HCFnDxmJJGdQReHesulvdi9rcLnWxxfI7LdwqIxONw/B4K4tr9NODS/IQvNxw17+z6MW6agAA4aM6aObm/C1Hxy0svLYzRRxCs9+sZqHlPimRx9xKq8j5Ruk11cGrsGYLjYL/aM9wy7ZOHe0O8cRw3uQbp1tJauJfCyD4f3srDzs=
+          file: out/archive/*
+          file_glob: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ jobs:
       deploy:
         provider: releases
         api_key:
-          secure: qWE/KeSH0bYu20gIaXKx0jh2v9MNzzUYBCNiy23kisIyFCdVDqgBFQSGIPHU8mQaO3pcYI3XoctJbirnDEMd5RDvNMZZfHOfEkebxWpY6Eo95SS78Xds4AU0IOA1ZFxzdgGL+1pvXtnjzuTXQD9w/APjKpJhiFsiiTbp1wfeahjBEWZIrR+UBrvQLiIlAOtG8O2Lh07CUSThtSRGNaoQ7q62jOV+bNNqK0ttaSO4AOZfGPzRZ7kM6dNwVlVnUzzHiJOQfZscu/W2QZEmFkOM0dQ6O2ZUxooZcthA59pZZIiwtS+tMfWEj6Tm77XuYfVDfGCXyoFu57lupUXC+fWUI1lbiNsVs88fQrTx28fix8nQOCT/oPd9l60ksagaCwa0YwCaYcs2aRFGVHOdcihFTLp36NY4/QjfsXSeMF3ZeCBwMnvJscngtKR3hzzR3mm69sfaWNPYZyzEG4TJadX1y9OiY8jrk3uQFjfH6JO4/Np2/zk55r0trCq6eiGUhv/HCFnDxmJJGdQReHesulvdi9rcLnWxxfI7LdwqIxONw/B4K4tr9NODS/IQvNxw17+z6MW6agAA4aM6aObm/C1Hxy0svLYzRRxCs9+sZqHlPimRx9xKq8j5Ruk11cGrsGYLjYL/aM9wy7ZOHe0O8cRw3uQbp1tJauJfCyD4f3srDzs=
+          secure: $GITHUB_TOKEN
         file: out/archive/*
         file_glob: true
+        on:
+          branch: feature/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
-language: generic
-services:
-  - docker
+language: shell
+os: linux
+services: docker
 branches:
   only:
     - feature/travis
     - /^untagged/
-jobs:
+matrix:
   include:
     - stage: build
+      env:
+        - TARGET=5.0.0-25-generic
+        - TARGET=4.9.125-linuxkit
       script:
-        - bash ./build 5.0.0-25-generic
+        - bash ./build $TARGET
     - stage: deploy
       deploy:
         provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ jobs:
       script:
         - bash ./build 5.0.0-25-generic
     - stage: deploy
-        deploy:
-          provider: releases
-          api_key:
-            secure: qWE/KeSH0bYu20gIaXKx0jh2v9MNzzUYBCNiy23kisIyFCdVDqgBFQSGIPHU8mQaO3pcYI3XoctJbirnDEMd5RDvNMZZfHOfEkebxWpY6Eo95SS78Xds4AU0IOA1ZFxzdgGL+1pvXtnjzuTXQD9w/APjKpJhiFsiiTbp1wfeahjBEWZIrR+UBrvQLiIlAOtG8O2Lh07CUSThtSRGNaoQ7q62jOV+bNNqK0ttaSO4AOZfGPzRZ7kM6dNwVlVnUzzHiJOQfZscu/W2QZEmFkOM0dQ6O2ZUxooZcthA59pZZIiwtS+tMfWEj6Tm77XuYfVDfGCXyoFu57lupUXC+fWUI1lbiNsVs88fQrTx28fix8nQOCT/oPd9l60ksagaCwa0YwCaYcs2aRFGVHOdcihFTLp36NY4/QjfsXSeMF3ZeCBwMnvJscngtKR3hzzR3mm69sfaWNPYZyzEG4TJadX1y9OiY8jrk3uQFjfH6JO4/Np2/zk55r0trCq6eiGUhv/HCFnDxmJJGdQReHesulvdi9rcLnWxxfI7LdwqIxONw/B4K4tr9NODS/IQvNxw17+z6MW6agAA4aM6aObm/C1Hxy0svLYzRRxCs9+sZqHlPimRx9xKq8j5Ruk11cGrsGYLjYL/aM9wy7ZOHe0O8cRw3uQbp1tJauJfCyD4f3srDzs=
-          file: out/archive/*
-          file_glob: true
+      deploy:
+        provider: releases
+        api_key:
+          secure: qWE/KeSH0bYu20gIaXKx0jh2v9MNzzUYBCNiy23kisIyFCdVDqgBFQSGIPHU8mQaO3pcYI3XoctJbirnDEMd5RDvNMZZfHOfEkebxWpY6Eo95SS78Xds4AU0IOA1ZFxzdgGL+1pvXtnjzuTXQD9w/APjKpJhiFsiiTbp1wfeahjBEWZIrR+UBrvQLiIlAOtG8O2Lh07CUSThtSRGNaoQ7q62jOV+bNNqK0ttaSO4AOZfGPzRZ7kM6dNwVlVnUzzHiJOQfZscu/W2QZEmFkOM0dQ6O2ZUxooZcthA59pZZIiwtS+tMfWEj6Tm77XuYfVDfGCXyoFu57lupUXC+fWUI1lbiNsVs88fQrTx28fix8nQOCT/oPd9l60ksagaCwa0YwCaYcs2aRFGVHOdcihFTLp36NY4/QjfsXSeMF3ZeCBwMnvJscngtKR3hzzR3mm69sfaWNPYZyzEG4TJadX1y9OiY8jrk3uQFjfH6JO4/Np2/zk55r0trCq6eiGUhv/HCFnDxmJJGdQReHesulvdi9rcLnWxxfI7LdwqIxONw/B4K4tr9NODS/IQvNxw17+z6MW6agAA4aM6aObm/C1Hxy0svLYzRRxCs9+sZqHlPimRx9xKq8j5Ruk11cGrsGYLjYL/aM9wy7ZOHe0O8cRw3uQbp1tJauJfCyD4f3srDzs=
+        file: out/archive/*
+        file_glob: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services: docker
 
 branches:
   only:
-    - feature/travis
+    - master
 
 env:
   # Userland build
@@ -30,3 +30,5 @@ deploy:
   upload-dir: $S3_FOLDER
   skip_cleanup: true
   local_dir: out/archive
+  on:
+    branch: master

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -34,6 +34,9 @@ The '-u' option will only build the userland. By default, it will build both for
 the first found kernel release, and then kernel only for the remainder. The '-z'
 option will specify the ZFS version(s) to build.
 
+When you add a new version, you will have to update the environment
+variables in .travis.yml to parallelize the builds.
+
 ## Testing
 
 You should be able to run the builds for any platforms that you are changing.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -42,7 +42,10 @@ platforms (this can take a while).
 
 ## Release
 
-There is currently no automated build & release process for ZFS releases.
-These must be manually built and uploaded to a GitHub release tag. The tag
-must be created in a draft state prior to artifacts being uploaded, otherwise
-any titan installs risk failing due to incomplete release binaries.
+We only need to publish the notion of a "current" release. Rather than
+creating a separate public repository (e.g. S3 bucket) with its own operational
+overhead, we are instead using GitHub releases. Every push to the master branch
+will create a new release (using the default "untagged-" prefix), and publish
+all the artifacts there. The Titan installation process will always look in
+the latest release for available downloads. This is all driven by a Travis CI
+job triggered on each push.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -27,15 +27,16 @@ The `build` script will iterate over the contents of the directory and invoke
 the zfs-builder container to perform the build.
 
 ```
-./build [-u] [-z zfs_version] [kernel_release ...]
+./build [-u] [-k] [-z zfs_version] [kernel_release ...]
 ```
 
-The '-u' option will only build the userland. By default, it will build both for
-the first found kernel release, and then kernel only for the remainder. The '-z'
-option will specify the ZFS version(s) to build.
+The '-u' option will only build userland, while '-k' will only build the kernel.
+By default, it will build both for the first found kernel release, and then
+kernel only for the remainder. The '-z' option will specify the ZFS version(s)
+to build.
 
 When you add a new version, you will have to update the environment
-variables in .travis.yml to parallelize the builds.
+variables in .travis.yml.
 
 ## Testing
 
@@ -45,10 +46,12 @@ platforms (this can take a while).
 
 ## Release
 
-We only need to publish the notion of a "current" release. Rather than
-creating a separate public repository (e.g. S3 bucket) with its own operational
-overhead, we are instead using GitHub releases. Every push to the master branch
-will create a new release (using the default "untagged-" prefix), and publish
-all the artifacts there. The Titan installation process will always look in
-the latest release for available downloads. This is all driven by a Travis CI
-job triggered on each push.
+We build releases on Travis, with every push triggering a new build. Once a
+particular set of binaries is built, it shouldn't ever need to be updated,
+so the Travis build will pass a URL via '-b' that can be used to check if
+a releases exists in a S3 bucket. If it does, then the build is skipped.
+Artifacts are then published to said S3 bucket.
+
+If we do need to re-build a particular release, we can remove it manually via
+the S3 console, or we could add a force flag to overwrite it if this turns out
+to be a common occurrence.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Titan ZFS builds
 
+[![Build Status](https://travis-ci.org/titan-data/zfs-releases.svg?branch=master)](https://travis-ci.org/titan-data/zfs-releases)
+
 This repository uses the [zfs-builder](https://github.com/titan-data/zfs-builder)
 image to build a set of well-known Linux ZFS binaries, for kernel and userland,
 suitable for use in the Titan project.

--- a/build
+++ b/build
@@ -7,6 +7,7 @@ src_dir=$PWD/src
 out_dir=$PWD/out
 archive_dir=$out_dir/archive
 build_dir=$out_dir/build
+force=false
 zfs_builder=titandata/zfs-builder:develop
 
 function usage() {
@@ -19,10 +20,13 @@ function die() {
   exit 1
 }
 
-while getopts ":uz:" o; do
+while getopts ":ufz:" o; do
   case "${o}" in
     u)
       userland_only=true
+      ;;
+    f)
+      force=true
       ;;
     z)
       zfs_versions=$OPTARG
@@ -55,25 +59,39 @@ for version in $zfs_versions; do
     fi
 
     mkdir -p $build_dir/$release || exit 1
-    docker run --rm -v /var/run/docker.sock:/var/run/docker.sock --network=host \
-      -e ZFS_VERSION=zfs-$version -e KERNEL_RELEASE=$release \
-      -e KERNEL_UNAME="$(cat $src_dir/$release/uname)" -e ZFS_CONFIG=$zfs_config \
-      -v $src_dir/$release:/config -v $build_dir/$release:/build \
-      $zfs_builder || exit 1
+    kernel_archive=zfs-$version-$release.tar.gz
+    userland_archive=zfs-$version-userland.tar.gz
+
+    if [[ -f $archive_dir/$kernel_archive && $force = false ]]; then
+        echo "Archive $kernel_archive already exists, skipping"
+    else
+        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock --network=host \
+          -e ZFS_VERSION=zfs-$version -e KERNEL_RELEASE=$release \
+          -e KERNEL_UNAME="$(cat $src_dir/$release/uname)" -e ZFS_CONFIG=$zfs_config \
+          -v $src_dir/$release:/config -v $build_dir/$release:/build \
+          $zfs_builder || exit 1
+    fi
 
     cd $build_dir/$release
+
     if [[ $zfs_config != kernel ]]; then
-      echo "Creating userland archive zfs-$version-userland.tar.gz"
-      tar -czf $archive_dir/zfs-$version-userland.tar.gz \
-        --exclude lib/modules --exclude lib/udev --exclude "lib/libzpool.*" \
-        --exclude sbin/zdb --exclude sbin/ztest sbin lib || exit 1
+        if [[ -f $archive_dir/$userland_archive && $force = false ]]; then
+            echo "Archive $userland_archive already exists, skipping"
+        else
+            echo "Creating userland archive $userland_archive"
+            tar -czf $archive_dir/$userland_archive \
+              --exclude lib/modules --exclude lib/udev --exclude "lib/libzpool.*" \
+              --exclude sbin/zdb --exclude sbin/ztest sbin lib || exit 1
+        fi
     fi
 
     first=false
     [[ $userland_only = true ]] && break
 
-    echo "Creating kernel archive zfs-$version-$release.tar.gz"
-    tar -czf $archive_dir/zfs-$version-$release.tar.gz lib/modules || exit 1
+    if [[ ! -f $archive_dir/$kernel_archive ]]; then
+        echo "Creating kernel archive $kernel_archive"
+        tar -czf $archive_dir/$kernel_archive lib/modules || exit 1
+    fi
   done
 done
 exit 0

--- a/build
+++ b/build
@@ -67,21 +67,21 @@ for version in $zfs_versions; do
     if [[ $userland_only = true ]]; then
       zfs_config=user
       if archive_exists $userland_archive; then
-          echo "Archive $userland_archive exists, skipping"
-          continue
+        echo "Archive $userland_archive exists, skipping"
+        continue
       fi
     elif [[ $first = true && $kernel_only = false ]]; then
       zfs_config=all
       if archive_exists $kernel_archive &&
-        archive_exists $userland_archive; then
-          echo "Archive $kernel_archive and $userland_archive exists, skipping"
-          continue
+          archive_exists $userland_archive; then
+        echo "Archive $kernel_archive and $userland_archive exists, skipping"
+        continue
       fi
     else
       zfs_config=kernel
       if archive_exists $kernel_archive; then
-          echo "Archive $kernel_archive exists, skipping"
-          continue
+        echo "Archive $kernel_archive exists, skipping"
+        continue
       fi
     fi
 
@@ -101,8 +101,8 @@ for version in $zfs_versions; do
     fi
 
     if [[ $zfs_config != user ]]; then
-        echo "Creating kernel archive $kernel_archive"
-        tar -czf $archive_dir/$kernel_archive lib/modules || exit 1
+      echo "Creating kernel archive $kernel_archive"
+      tar -czf $archive_dir/$kernel_archive lib/modules || exit 1
     fi
 
     first=false

--- a/build
+++ b/build
@@ -30,7 +30,7 @@ function archive_exists() {
 while getopts ":ukb:z:" o; do
   case "${o}" in
     b)
-      artifact_url=$OPTARG
+      archive_url=$OPTARG
       ;;
     u)
       userland_only=true

--- a/build
+++ b/build
@@ -68,14 +68,14 @@ for version in $zfs_versions; do
       fi
     elif [[ $first = true && $kernel_only = false ]]; then
       zfs_config=all
-      if [[ -f $archive_dir/$kernel_archive && $force = false ]]; then
+      if [[ -f $archive_dir/$kernel_archive &&
+            -f $archive_dir/$userland_archive && $force = false ]]; then
           echo "Archive $kernel_archive exists, skipping"
           continue
       fi
     else
       zfs_config=kernel
-      if [[ -f $archive_dir/$kernel_archive &&
-            -f $arhicve_dir/$userland_archive && $force = false ]]; then
+      if [[ -f $archive_dir/$kernel_archive && $force = false ]]; then
           echo "Archive $kernel_archive and $userland_archive exists, skipping"
           continue
       fi

--- a/build
+++ b/build
@@ -10,8 +10,8 @@ src_dir=$PWD/src
 out_dir=$PWD/out
 archive_dir=$out_dir/archive
 build_dir=$out_dir/build
-force=false
 zfs_builder=titandata/zfs-builder:develop
+archive_url=
 
 function usage() {
   echo "Usage: $0 [-u] [kernel_release ...]" 1>&2
@@ -23,16 +23,20 @@ function die() {
   exit 1
 }
 
-while getopts ":ukfz:" o; do
+function archive_exists() {
+  [[ -n $archive_url ]] && curl -output /dev/null --fail --silent --head $archive_url/$1
+}
+
+while getopts ":ukb:z:" o; do
   case "${o}" in
+    b)
+      artifact_url=$OPTARG
+      ;;
     u)
       userland_only=true
       ;;
     k)
       kernel_only=true
-      ;;
-    f)
-      force=true
       ;;
     z)
       zfs_versions=$OPTARG
@@ -62,20 +66,20 @@ for version in $zfs_versions; do
 
     if [[ $userland_only = true ]]; then
       zfs_config=user
-      if [[ -f $archive_dir/$userland_archive && $force = false ]]; then
+      if archive_exists $userland_archive; then
           echo "Archive $userland_archive exists, skipping"
           continue
       fi
     elif [[ $first = true && $kernel_only = false ]]; then
       zfs_config=all
-      if [[ -f $archive_dir/$kernel_archive &&
-            -f $archive_dir/$userland_archive && $force = false ]]; then
+      if archive_exists $kernel_archive &&
+        archive_exists $userland_archive; then
           echo "Archive $kernel_archive exists, skipping"
           continue
       fi
     else
       zfs_config=kernel
-      if [[ -f $archive_dir/$kernel_archive && $force = false ]]; then
+      if archive_exists $kernel_archive; then
           echo "Archive $kernel_archive and $userland_archive exists, skipping"
           continue
       fi

--- a/build
+++ b/build
@@ -74,13 +74,13 @@ for version in $zfs_versions; do
       zfs_config=all
       if archive_exists $kernel_archive &&
         archive_exists $userland_archive; then
-          echo "Archive $kernel_archive exists, skipping"
+          echo "Archive $kernel_archive and $userland_archive exists, skipping"
           continue
       fi
     else
       zfs_config=kernel
       if archive_exists $kernel_archive; then
-          echo "Archive $kernel_archive and $userland_archive exists, skipping"
+          echo "Archive $kernel_archive exists, skipping"
           continue
       fi
     fi

--- a/build
+++ b/build
@@ -24,7 +24,7 @@ function die() {
 }
 
 function archive_exists() {
-  [[ -n $archive_url ]] && curl -output /dev/null --fail --silent --head $archive_url/$1
+  [[ -n $archive_url ]] && curl --output /dev/null --fail --silent --head $archive_url/$1
 }
 
 while getopts ":ukb:z:" o; do

--- a/build
+++ b/build
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 zfs_versions=0.8.1
 userland_only=false
 kernel_only=false

--- a/build
+++ b/build
@@ -7,7 +7,7 @@ src_dir=$PWD/src
 out_dir=$PWD/out
 archive_dir=$out_dir/archive
 build_dir=$out_dir/build
-zfs_builder=titandata/zfs-builder:latest
+zfs_builder=titandata/zfs-builder:develop
 
 function usage() {
   echo "Usage: $0 [-u] [kernel_release ...]" 1>&2

--- a/build
+++ b/build
@@ -55,7 +55,7 @@ for version in $zfs_versions; do
     fi
 
     mkdir -p $build_dir/$release || exit 1
-    docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
+    docker run --rm -v /var/run/docker.sock:/var/run/docker.sock --network=host \
       -e ZFS_VERSION=zfs-$version -e KERNEL_RELEASE=$release \
       -e KERNEL_UNAME="$(cat $src_dir/$release/uname)" -e ZFS_CONFIG=$zfs_config \
       -v $src_dir/$release:/config -v $build_dir/$release:/build \

--- a/build
+++ b/build
@@ -2,6 +2,7 @@
 
 zfs_versions=0.8.1
 userland_only=false
+kernel_only=false
 kernel_releases=
 src_dir=$PWD/src
 out_dir=$PWD/out
@@ -20,10 +21,13 @@ function die() {
   exit 1
 }
 
-while getopts ":ufz:" o; do
+while getopts ":ukfz:" o; do
   case "${o}" in
     u)
       userland_only=true
+      ;;
+    k)
+      kernel_only=true
       ;;
     f)
       force=true
@@ -50,48 +54,53 @@ for version in $zfs_versions; do
     [[ -d $src_dir/$release ]] || die "Unknown kernel release $release"
     [[ -f $src_dir/$release/uname ]] || die "Missing uname file for $release"
 
-    if [[ $userland_only = true ]]; then
-      zfs_config=user
-    elif [[ $first = true ]]; then
-      zfs_config=all
-    else
-      zfs_config=kernel
-    fi
-
     mkdir -p $build_dir/$release || exit 1
     kernel_archive=zfs-$version-$release.tar.gz
     userland_archive=zfs-$version-userland.tar.gz
 
-    if [[ -f $archive_dir/$kernel_archive && $force = false ]]; then
-        echo "Archive $kernel_archive already exists, skipping"
+    if [[ $userland_only = true ]]; then
+      zfs_config=user
+      if [[ -f $archive_dir/$userland_archive && $force = false ]]; then
+          echo "Archive $userland_archive exists, skipping"
+          continue
+      fi
+    elif [[ $first = true && $kernel_only = false ]]; then
+      zfs_config=all
+      if [[ -f $archive_dir/$kernel_archive && $force = false ]]; then
+          echo "Archive $kernel_archive exists, skipping"
+          continue
+      fi
     else
-        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock --network=host \
-          -e ZFS_VERSION=zfs-$version -e KERNEL_RELEASE=$release \
-          -e KERNEL_UNAME="$(cat $src_dir/$release/uname)" -e ZFS_CONFIG=$zfs_config \
-          -v $src_dir/$release:/config -v $build_dir/$release:/build \
-          $zfs_builder || exit 1
+      zfs_config=kernel
+      if [[ -f $archive_dir/$kernel_archive &&
+            -f $arhicve_dir/$userland_archive && $force = false ]]; then
+          echo "Archive $kernel_archive and $userland_archive exists, skipping"
+          continue
+      fi
     fi
+
+    docker run --rm -v /var/run/docker.sock:/var/run/docker.sock --network=host \
+      -e ZFS_VERSION=zfs-$version -e KERNEL_RELEASE=$release \
+      -e KERNEL_UNAME="$(cat $src_dir/$release/uname)" -e ZFS_CONFIG=$zfs_config \
+      -v $src_dir/$release:/config -v $build_dir/$release:/build \
+      $zfs_builder || exit 1
 
     cd $build_dir/$release
 
     if [[ $zfs_config != kernel ]]; then
-        if [[ -f $archive_dir/$userland_archive && $force = false ]]; then
-            echo "Archive $userland_archive already exists, skipping"
-        else
-            echo "Creating userland archive $userland_archive"
-            tar -czf $archive_dir/$userland_archive \
-              --exclude lib/modules --exclude lib/udev --exclude "lib/libzpool.*" \
-              --exclude sbin/zdb --exclude sbin/ztest sbin lib || exit 1
-        fi
+        echo "Creating userland archive $userland_archive"
+        tar -czf $archive_dir/$userland_archive \
+          --exclude lib/modules --exclude lib/udev --exclude "lib/libzpool.*" \
+          --exclude sbin/zdb --exclude sbin/ztest sbin lib || exit 1
+    fi
+
+    if [[ $zfs_config != user ]]; then
+        echo "Creating kernel archive $kernel_archive"
+        tar -czf $archive_dir/$kernel_archive lib/modules || exit 1
     fi
 
     first=false
     [[ $userland_only = true ]] && break
-
-    if [[ ! -f $archive_dir/$kernel_archive ]]; then
-        echo "Creating kernel archive $kernel_archive"
-        tar -czf $archive_dir/$kernel_archive lib/modules || exit 1
-    fi
   done
 done
 exit 0


### PR DESCRIPTION
## Issues Addressed

None.

## Proposed Changes

What a long and winding road it's been. This adds Travis support to build the ZFS releases. As a result of switching to this model, we had to bite the bullet and move to hosting artifacts in S3 instead of force-fitting them into GitHub releases. The build will first check to see if the artifact exists under the given URL, skipping the build if that's the case.

All of the configuration (AWS account and S3 bucket) is passed in via Travis.

## Testing

Ran and re-ran builds within my test account. Should all work, though I did not test with the branch switched to "master", but did change the travis build file and badge link.