### PR TITLE
Add support for latest Travis environment

### DIFF
--- a/build
+++ b/build
@@ -10,7 +10,7 @@ src_dir=$PWD/src
 out_dir=$PWD/out
 archive_dir=$out_dir/archive
 build_dir=$out_dir/build
-zfs_builder=titandata/zfs-builder:develop
+zfs_builder=titandata/zfs-builder:latest
 archive_url=
 
 function usage() {

--- a/src/4.15.0-1040-gcp/uname
+++ b/src/4.15.0-1040-gcp/uname
@@ -1,0 +1,1 @@
+Linux system 4.15.0-1040-gcp #42-Ubuntu SMP Wed Aug 7 15:17:54 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux


### PR DESCRIPTION
## Proposed Changes

Travis is starting to use a more recent Ubuntu version, we need to add ZFS modules for it. While I was here, I noticed that I accidentally pushed a change to the build script to use the in-development ZFS builder when I was testing new changes. That should be reverted.

## Testing

Built locally.