### PR TITLE
Add CentOS 3.10.0-957.27.2.el7.x86_64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
   - MODE=-k KERNEL=4.15.0-1044-aws
   # CentOS variants
   - MODE=-k KERNEL=3.10.0-957.1.3.el7.x86_64
+  - MODE=-k KERNEL=3.10.0-957.27.2.el7.x86_64
 
 script:
   - bash ./build -b $S3_URL $MODE $KERNEL

--- a/src/3.10.0-957.27.2.el7.x86_64/centos-release
+++ b/src/3.10.0-957.27.2.el7.x86_64/centos-release
@@ -1,0 +1,1 @@
+CentOS Linux release 7.6.1810 (Core)

--- a/src/3.10.0-957.27.2.el7.x86_64/uname
+++ b/src/3.10.0-957.27.2.el7.x86_64/uname
@@ -1,0 +1,1 @@
+Linux localhost.localdomain 3.10.0-957.27.2.el7.x86_64 #1 SMP Mon Jul 29 17:46:05 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux


### PR DESCRIPTION
## Proposed Changes

This adds support for the kernel used in the latest CentOS 7 ISO:

`http://yum.tamu.edu/centos/7.6.1810/isos/x86_64/CentOS-7-x86_64-NetInstall-1810.torrent`

## Testing

`./build 3.10.0-957.27.2.el7.x86_64`