### PR TITLE
Add support for 5.0.0-1016-azure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   - MODE=-k KERNEL=4.9.125-linuxkit
   # Ubuntu variants
   - MODE=-k KERNEL=5.0.0-25-generic
+  - MODE=-k KERNEL=5.0.0-1016-azure
   - MODE=-k KERNEL=4.15.0-1040-gcp
   - MODE=-k KERNEL=4.15.0-1034-gcp
   - MODE=-k KERNEL=4.15.0-1044-aws

--- a/src/5.0.0-1016-azure/uname
+++ b/src/5.0.0-1016-azure/uname
@@ -1,0 +1,1 @@
+Linux fv-az88 5.0.0-1016-azure #17~18.04.1-Ubuntu SMP Thu Aug 15 15:58:09 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux


### PR DESCRIPTION
## Issues Addressed

Fixes #12 

## Proposed Changes

Added `Linux fv-az88 5.0.0-1016-azure #17~18.04.1-Ubuntu SMP Thu Aug 15 15:58:09 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux`

## Testing

`./build 5.0.0-1016-azure`