### PR TITLE
add ubuntu variants for GitHub

### DIFF
--- a/src/5.0.0-1016-azure/uname
+++ b/src/5.0.0-1016-azure/uname
@@ -1,0 +1,1 @@
+Linux localhost 5.0.0-1016-azure #17~18.04.1-Ubuntu SMP Thu Aug 15 15:58:09 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux

--- a/src/5.0.0-1020-azure/uname
+++ b/src/5.0.0-1020-azure/uname
@@ -1,0 +1,1 @@
+Linux localhost 5.0.0-1020-azure #21~18.04.1-Ubuntu SMP Fri Sep 13 14:10:02 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux


### PR DESCRIPTION
## Proposed Changes

We want to be able to run endtoend tests in GitHub, this adds some pre-built images for the Azure variants found there. While we had the 1016 variant already, they have now moved on to 1020.

## Testing

Built locally.